### PR TITLE
pin external action to avoid supply chain attack

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
   using: "composite"
   steps:
     - name: Set the ruby version
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a
       with:
         ruby-version: 3.2
         bundler-cache: true


### PR DESCRIPTION
I pinned the external action references in lewagon/wait-on-check-action from branches/tags to full commit SHAs.
This reduces the risk of supply chain attacks caused by tag replacement or branch updates.

https://github.com/ruby/setup-ruby/commit/0481980f17b760ef6bca5e8c55809102a0af1e5a

<img width="1722" height="904" alt="2025-09-25 15 53 55" src="https://github.com/user-attachments/assets/674f41f5-01dc-455c-923c-f38150ad96a0" />
